### PR TITLE
Adding tz to datetime now to prevent booking wrong day to to timezone…

### DIFF
--- a/padel7_booking_bot/bot/utils.py
+++ b/padel7_booking_bot/bot/utils.py
@@ -3,6 +3,8 @@ import logging
 import config.settings as settings
 import sys
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
 from selenium import webdriver
 from selenium.common.exceptions import JavascriptException
 from selenium.webdriver.chrome.service import Service
@@ -88,11 +90,11 @@ def save_screenshot(driver, filename):
 
 def get_default_book_date():
     # Calculate the date 10 days from today
-    return datetime.now() + timedelta(days=10)
+    return datetime.now(ZoneInfo('Europe/Madrid')) + timedelta(days=10)
 
 
 def get_default_book_time_slot():
-    # Calculate the date 10 days from today
+    # Set default time slot to 18:00-19:30
     return "18:00-19:30"
 
 

--- a/padel7_booking_bot/main.py
+++ b/padel7_booking_bot/main.py
@@ -93,14 +93,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "--date",
         type=str,
-        help="Date for booking in YYYY-MM-DD format.",
-        default=utils.get_default_book_date().strftime("%Y-%m-%d"),
+        help="Date for booking in YYYY-MM-DD format."
     )
     parser.add_argument(
         "--time",
         type=str,
-        help="Time for booking in HH:MM format.",
-        default=utils.get_default_book_time_slot(),
+        help="Time for booking in HH:MM format."
     )
     parser.add_argument(
         "--court-type",

--- a/padel7_booking_bot/pyproject.toml
+++ b/padel7_booking_bot/pyproject.toml
@@ -5,6 +5,10 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "my-booker-buddy"
 version = "1.0.0"
+dependencies = [
+    "freezegun>=1.5.3",
+    "pytest>=8.4.1",
+]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/padel7_booking_bot/tests/integration/test_timezone.py
+++ b/padel7_booking_bot/tests/integration/test_timezone.py
@@ -1,0 +1,27 @@
+from freezegun import freeze_time
+from datetime import datetime
+from bot.utils import get_default_book_date, get_default_book_time_slot
+import pytest
+from zoneinfo import ZoneInfo
+
+test_cases = [
+    '2025-07-11 00:00:00',
+    '2025-07-12 00:00:00',
+    '2025-07-13 00:00:00',
+]
+
+answers = [
+    '2025-07-21',
+    '2025-07-22',
+    '2025-07-23',
+]
+
+@pytest.mark.parametrize("test_case, answer", zip(test_cases, answers))
+def test_get_default_book_date_no_freeze(test_case, answer):
+    europe_tz = ZoneInfo('Europe/Warsaw')
+    dt = datetime.strptime(test_case, "%Y-%m-%d %H:%M:%S").replace(tzinfo=europe_tz)
+    utc_dt = dt.astimezone(ZoneInfo('UTC'))
+
+    with freeze_time(utc_dt):
+        assert get_default_book_date().strftime("%Y-%m-%d") == answer
+        assert get_default_book_time_slot() == "18:00-19:30"


### PR DESCRIPTION
There was an issue where the server was in a timezone and the booking in another, hence when getting the date and adding 10 days on top, we ended up booking the wrong day (monday)

By setting up the timezone in the datetime.now function, we prevent this issue from happening.

I have also removed the defaults, just in case the parser is not correctly set up in the right time zone, but they are still covered in the booking function.

Finally added a test that shows (if you remove the zoneinfo fix) the error.